### PR TITLE
[Backend] [FrontEnd] Add gates endpoints and add matrix component gate

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4,6 +4,8 @@ import sys
 import numpy as np
 from flask_cors import CORS
 from controllers.superposition_circuit.circuit import setup_circuit, run_cirq
+from controllers.quantum_Single_Qubit_Gates.app import Hadamard_gate,Pauli_Y_gate,Pauli_Z_gate,Phase_gate,T_gate,X_gate
+
 app = Flask(__name__)
 CORS(app, resources={r"/*": {"origins": "http://localhost:3000"}}) # to allow NextJs to fetch data 
 
@@ -38,7 +40,27 @@ def handle_setup_circuit():
 def handle_run_cirq(): 
     return run_cirq()
 
-
+@app.route('/hadamardGate', methods=['GET']) 
+def hadamard_gate_info(): 
+    return {
+            "message": "Gate created successfully",
+            "gate": Hadamard_gate().tolist() 
+        }
+@app.route('/xGate', methods=['GET']) 
+def x_gate_info(): 
+    return jsonify(X_gate().tolist()) 
+@app.route('/pauliYGate', methods=['GET']) 
+def pauli_y_gate_info(): 
+    return jsonify(Pauli_Y_gate().tolist()) 
+@app.route('/pauliZGate', methods=['GET']) 
+def pauli_z_gate_info(): 
+    return jsonify(Pauli_Z_gate().tolist()) 
+@app.route('/phaseGate', methods=['GET']) 
+def phase_gate_info(): 
+    return jsonify(Phase_gate().tolist())
+@app.route('/tGate', methods=['GET'])
+def t_gate_info(): 
+    return jsonify(T_gate().tolist()) 
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/quantum-simulator-on-cirq/app/layout.tsx
+++ b/quantum-simulator-on-cirq/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
 import ClientProvider from '@/hooks/clientProvider';
+import StyledComponentsRegistry from "@/lib/StyledComponentsRegistry";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -27,9 +28,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        <ClientProvider>
-          {children}
-        </ClientProvider>
+        <StyledComponentsRegistry>
+          <ClientProvider>
+            {children}
+          </ClientProvider>
+        </StyledComponentsRegistry>
       </body>
     </html>
   );

--- a/quantum-simulator-on-cirq/app/page.tsx
+++ b/quantum-simulator-on-cirq/app/page.tsx
@@ -1,51 +1,76 @@
 'use client';
-import styles from "./page.module.css";
+
+import React from 'react';
+import styled from 'styled-components';
 import Stack from '@mui/material/Stack';
 import Button from '@mui/material/Button';
-import { useSetupCircuitMutation, useRunCircuitMutation } from '@/feature/api';
+import { useSetupCircuitMutation, useRunCircuitMutation, useLazyHadamardGateQuery } from '@/feature/api';
+import Matrix from '@/components/matrixComponent/matrixComponent';
+
+const Page = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+`;
+
+const Title = styled.h1`
+  font-size: 24px;
+  margin: 20px 0;
+`;
+
+const Error = styled.h1`
+  color: red;
+`;
 
 export default function Home() {
   const [setupCircuit, { data: setupData, isError: setupError }] = useSetupCircuitMutation();
   const [runCircuit, { data: runData, isError: runError }] = useRunCircuitMutation();
+  const [getHadamardGate, { data: hadamardGate, error }] = useLazyHadamardGateQuery();
 
   const handelSetupAndRunCircuitNumber1 = async (arg: unknown) => {
     try {
       const setupResult = await setupCircuit(arg).unwrap();
       if (setupResult) {
-        console.log("happen2");
         await runCircuit(arg).unwrap();
       }
     } catch (error) {
       console.error("An error occurred during the setup or run process:", error);
     }
-  }
-
-  const setupDataComponent = setupData && (
-    <>
-      <h1>{setupData?.message}</h1>
-      <h1>{setupData?.circuit}</h1>
-    </>
-  )
-
-  const runDataComponent = runData && (
-    <>
-      <h1>{runData?.message}</h1>
-      <h1>{runData?.circuit}</h1>
-    </>
-  )
+  };
 
   return (
-    <div className={styles.page}>
+    <Page>
       <Stack spacing={2} direction="row">
-        <Button key="setup and run circuit" onClick={handelSetupAndRunCircuitNumber1} variant="contained">
+        <Button onClick={() => handelSetupAndRunCircuitNumber1(null)} variant="contained">
           Build a Simple Circuit
         </Button>
-        {setupDataComponent}
-        {runDataComponent}
-        {setupError && <h1> Error in setup the circuit </h1>}
-        {runError && <h1> Error in running the circuit </h1>}
       </Stack>
-    </div>
+      <Stack>
+        <Button onClick={() => getHadamardGate('')} variant="contained">
+          Hadamard Gate
+        </Button>
+      </Stack>
+
+      {setupData && (
+        <>
+          <Title>{setupData?.message}</Title>
+          <Title>{setupData?.circuit}</Title>
+        </>
+      )}
+      {runData && (
+        <>
+          <Title>{runData?.message}</Title>
+          <Title>{runData?.circuit}</Title>
+        </>
+      )}
+      {setupError && <Error>Error in setup the circuit</Error>}
+      {runError && <Error>Error in running the circuit</Error>}
+      {error && <Error>Hadamard Gate error: {error.toString()}</Error>}
+
+      {hadamardGate && (
+        <Matrix data={hadamardGate?.gate} />
+      )}
+    </Page>
   );
 }
-

--- a/quantum-simulator-on-cirq/components/matrixComponent/matrixComponent.tsx
+++ b/quantum-simulator-on-cirq/components/matrixComponent/matrixComponent.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import React from 'react';
+import styled from 'styled-components';
+
+const MatrixContainer = styled.div`
+  display: inline-block;
+  border: 1px solid #ccc;
+  padding: 10px;
+  margin: 10px;
+`;
+
+const MatrixRow = styled.div`
+  display: flex;
+`;
+
+const MatrixCell = styled.div`
+  max-width: 250px ; 
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #ccc;
+  margin: -1px 0 0 -1px; 
+  overflow: hidden; 
+  text-overflow: ellipsis;  
+  white-space: nowrap;  
+  padding:20px
+`;
+
+type MatrixProps = {
+  data: (number | string)[][];
+};
+
+const Matrix: React.FC<MatrixProps> = ({ data }) => {
+  return (
+    <MatrixContainer>
+      {data?.map((row, rowIndex) => (
+        <MatrixRow key={rowIndex}>
+          {row.map((value, colIndex) => (
+            <MatrixCell key={colIndex}>
+              {value}
+            </MatrixCell>
+          ))}
+        </MatrixRow>
+      ))}
+    </MatrixContainer>
+  );
+};
+
+export default Matrix;

--- a/quantum-simulator-on-cirq/feature/api.js
+++ b/quantum-simulator-on-cirq/feature/api.js
@@ -1,28 +1,91 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 export const circuitApi = createApi({
-  reducerPath: 'circuitApi',
-  baseQuery: fetchBaseQuery({ baseUrl: 'http://127.0.0.1:5000' }),
+  reducerPath: "circuitApi",
+  baseQuery: fetchBaseQuery({ baseUrl: 'http://127.0.0.1:5000'}),
   endpoints: (builder) => ({
     setupCircuit: builder.mutation({
       query: () => ({
-        url: '/setup-circuit',
-        method: 'POST',
+        url: "/setup-circuit",
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
       }),
     }),
     runCircuit: builder.mutation({
       query: () => ({
-        url: '/run-cirq',
-        method: 'POST',
+        url: "/run-cirq",
+        method: "POST",
+      }),
+    }),
+    hadamardGate: builder.query({
+      query: () => ({
+        url: "/hadamardGate",
+        method: "GET",
+      }),
+    }),
+    xGate: builder.query({
+      query: () => ({
+        url: "/xGate",
+        method: "GET",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
+        },
+      }),
+    }),
+    pauliYGate: builder.query({
+      query: () => ({
+        url: "/pauliYGate",
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+    }),
+    pauliZGate: builder.query({
+      query: () => ({
+        url: "/pauliZGate",
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+    }),
+    phaseGate: builder.query({
+      query: () => ({
+        url: "/phaseGate",
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+    }),
+    tGate: builder.query({
+      query: () => ({
+        url: "/tGate",
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
         },
       }),
     }),
   }),
 });
 
-export const { useSetupCircuitMutation, useRunCircuitMutation } = circuitApi;
+export const {
+  useSetupCircuitMutation,
+  useRunCircuitMutation,
+  useHadamardGateQuery,
+  useXGateQuery,
+  usePauliYGateQuery,
+  usePauliZGateQuery,
+  usePhaseGateQuery,
+  useTGateQuery,
+  useLazyHadamardGateQuery,
+  useLazyPauliYGateQuery,
+  useLazyPauliZGateQuery,
+  useLazyPhaseGateQuery,
+  useLazyTGateQuery,
+  useLazyXGateQuery,
+} = circuitApi;

--- a/quantum-simulator-on-cirq/lib/StyledComponentsRegistry.tsx
+++ b/quantum-simulator-on-cirq/lib/StyledComponentsRegistry.tsx
@@ -1,0 +1,42 @@
+'use client'
+import React, { useState } from "react";
+import { useServerInsertedHTML } from "next/navigation";
+import { ServerStyleSheet, StyleSheetManager } from "styled-components";
+
+// Assuming `isPropValid` is defined somewhere
+const isPropValid = (propName: string) => true;
+
+interface StyledComponentsRegistryProps {
+  children: React.ReactNode;
+  props?: Record<string, unknown>; // Adjust the type as needed
+}
+
+export default function StyledComponentsRegistry({
+  children,
+  props,
+}: StyledComponentsRegistryProps) {
+  const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());
+
+  useServerInsertedHTML(() => {
+    const styles = styledComponentsStyleSheet.getStyleElement();
+    styledComponentsStyleSheet.instance.clearTag();
+    return <>{styles}</>;
+  });
+
+  if (typeof window !== "undefined") return <>{children}</>;
+
+  return (
+    <StyleSheetManager
+      enableVendorPrefixes
+      shouldForwardProp={(propName, elementToBeRendered) => {
+        return typeof elementToBeRendered === "string"
+          ? isPropValid(propName)
+          : true;
+      }}
+      {...(props || {})}
+      sheet={styledComponentsStyleSheet.instance}
+    >
+        {children}
+    </StyleSheetManager>
+  );
+}

--- a/quantum-simulator-on-cirq/package.json
+++ b/quantum-simulator-on-cirq/package.json
@@ -26,5 +26,8 @@
     "eslint": "^8",
     "eslint-config-next": "15.0.3",
     "typescript": "^5"
+  },
+  "resolutions": {
+    "styled-components": "^5"
   }
 }


### PR DESCRIPTION
# What was done?
This PR introduces several key features and improvements to the project:

- Added Gate Endpoints: Implemented new endpoints for various quantum gates (Hadamard, X, Pauli-Y, Pauli-Z, Phase, T) in the RTK Query API, allowing for more flexible circuit configurations.

- Matrix Component: Created a reusable Matrix component using styled-components to display matrix representations of quantum gates results. This component enhances the visualization of quantum operations in the frontend.

- Styled Components: Transitioned from CSS modules to styled-components for better encapsulation, maintainability, and dynamic styling of the application's UI elements.

## Changes
### API Enhancements

Added new endpoints for quantum gates in circuitApi:

- setupCircuit

- runCircuit

- hadamardGate

- xGate

- pauliYGate

- pauliZGate

- phaseGate

- tGate

## Frontend Improvements

### Matrix Component

- Created a Matrix component using styled-components.

- Displays matrix data in a structured and visually appealing format.

- Handles overflow and large numbers gracefully.

- Styled Components

- Updated Home component to use styled-components for layout and styling.

- E-nsured consistent styling across the application.
